### PR TITLE
Use binary mode for jq so it works on Windows

### DIFF
--- a/build-utils/list-bin-targets
+++ b/build-utils/list-bin-targets
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 cargo metadata --format-version 1 |
-  jq -r '
+  jq -br '
     .workspace_members as $ws |
     .packages[] | select(.id as $id | $ws | contains([$id])) |
     .targets[] | select(.kind == ["bin"]) |


### PR DESCRIPTION
In text mode, windows adds those pesky `\r` (carriage return) symbols, and breaks bash scripts iterating over the script output. Use binary mode to prevent Windows messing with the outputs we print.