### PR TITLE
Switch to workflow calls

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -1,42 +1,16 @@
-name: build
-
 on:
-  push:
-    tags:
-      - "v*.*.*"
-  schedule:
-    - cron: "0 20 * * 0"
-  workflow_dispatch:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.event_name != 'merge_group' }}
+  workflow_call:
+    inputs:
+      release-artifact-upload-url:
+        required: false
+        type: string
+        description: The URL for release artifact uploads; if unset the release uploads are skipped.
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  draft-release:
-    name: Create a release draft
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-24.04
-    outputs:
-      release-id: ${{ steps.create-release.outputs.id }}
-      upload-url: ${{ steps.create-release.outputs.upload_url }}
-      html-url: ${{ steps.create-release.outputs.html_url }}
-    timeout-minutes: 50
-    permissions:
-      contents: write
-    steps:
-      - name: Create release
-        id: create-release
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: false
-          draft: true
-          generateReleaseNotes: true
-
   plan:
     name: Plan the execution
     runs-on: ubuntu-24.04
@@ -56,13 +30,11 @@ jobs:
   build:
     needs:
       - plan
-      - draft-release
-    if: ${{ always() && needs.plan.result == 'success' && (!startsWith(github.ref, 'refs/tags/') || needs.draft-release.result == 'success') }}
     strategy:
       matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
       fail-fast: false
     name: |-
-      ${{ matrix.plan.mode.platformIndependent == true && matrix.plan.mode.name || format('{0} / {1}', matrix.plan.platform.name, matrix.plan.mode.name) }}
+      ${{ matrix.plan.mode.platformIndependent == true && matrix.plan.mode.name || format('{1} @ {0}', matrix.plan.platform.name, matrix.plan.mode.name) }}
     runs-on: ${{ matrix.plan.platform.os }}
     env: ${{ matrix.plan.platform.env }}
     timeout-minutes: 120
@@ -105,31 +77,7 @@ jobs:
 
       - name: Upload release archive
         uses: shogo82148/actions-upload-release-asset@v1
-        if: startsWith(github.ref, 'refs/tags/')
+        if: inputs.release-artifact-upload-url != ''
         with:
-          upload_url: ${{ needs.draft-release.outputs.upload-url }}
+          upload_url: ${{ inputs.release-artifact-upload-url }}
           asset_path: target/build-archives/archives/*.tar.gz
-
-  publish-release:
-    needs:
-      - draft-release
-      - build
-    name: Publish release
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-24.04
-    timeout-minutes: 50
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        uses: actions/github-script@v8
-        env:
-          RELEASE_ID: ${{ needs.draft-release.outputs.release-id }}
-        with:
-          script: |
-            github.rest.repos.updateRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: process.env.RELEASE_ID,
-              draft: false
-            });

--- a/.github/workflows/_code.yml
+++ b/.github/workflows/_code.yml
@@ -1,17 +1,5 @@
-name: code
-
 on:
-  push:
-    branches:
-      - "**"
-      - "!gh-readonly-queue/**"
-  merge_group:
-  schedule:
-    - cron: "0 20 * * 0"
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.event_name != 'merge_group' }}
+  workflow_call:
 
 defaults:
   run:
@@ -44,7 +32,7 @@ jobs:
       matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
       fail-fast: false
     name: |-
-      ${{ matrix.plan.mode.platformIndependent == true && matrix.plan.mode.name || format('{0} / {1}', matrix.plan.platform.name, matrix.plan.mode.name) }}
+      ${{ matrix.plan.mode.platformIndependent == true && matrix.plan.mode.name || format('{1} @ {0}', matrix.plan.platform.name, matrix.plan.mode.name) }}
     runs-on: ${{ matrix.plan.platform.os }}
     env: ${{ matrix.plan.platform.env }}
     timeout-minutes: 50

--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -1,21 +1,8 @@
-name: docker
-
 on:
-  push:
-    branches:
-      - "**"
-      - "!gh-readonly-queue/**"
-    tags:
-      - "v*.*.*"
-  merge_group:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.event_name != 'merge_group' }}
+  workflow_call:
 
 jobs:
   docker:
-    name: Docker
     runs-on: ubuntu-24.04
     timeout-minutes: 50
     permissions:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,43 @@
+# Development process support.
+
+name: dev
+
+on:
+  push:
+    branches:
+      - "**"
+      - "!gh-readonly-queue/**"
+  merge_group:
+  schedule:
+    - cron: "0 20 * * 0"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.event_name != 'merge_group' }}
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  RUSTDOCFLAGS: "-D warnings"
+
+jobs:
+  code:
+    uses: ./.github/workflows/_code.yml
+    secrets: inherit
+    permissions:
+      contents: read
+
+  build:
+    uses: ./.github/workflows/_build.yml
+    secrets: inherit
+    permissions:
+      contents: write
+
+  docker:
+    uses: ./.github/workflows/_docker.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -29,12 +29,6 @@ jobs:
     permissions:
       contents: read
 
-  build:
-    uses: ./.github/workflows/_build.yml
-    secrets: inherit
-    permissions:
-      contents: write
-
   docker:
     uses: ./.github/workflows/_docker.yml
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+# Release process support.
+
+name: release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  schedule:
+    - cron: "0 20 * * 0"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.event_name != 'merge_group' }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  draft-release:
+    name: Create a release draft
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-24.04
+    outputs:
+      release-id: ${{ steps.create-release.outputs.id }}
+      upload-url: ${{ steps.create-release.outputs.upload_url }}
+      html-url: ${{ steps.create-release.outputs.html_url }}
+    timeout-minutes: 50
+    permissions:
+      contents: write
+    steps:
+      - name: Create release
+        id: create-release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: false
+          draft: true
+          generateReleaseNotes: true
+
+  build:
+    needs:
+      - draft-release
+    uses: ./.github/workflows/_build.yml
+    secrets: inherit
+    permissions:
+      contents: write
+    with:
+      release-artifact-upload-url: ${{ needs.draft-release.outputs.upload-url }}
+
+  docker:
+    uses: ./.github/workflows/_docker.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+
+  publish-release:
+    needs:
+      - draft-release
+      - build
+    name: Publish release
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 50
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        uses: actions/github-script@v8
+        env:
+          RELEASE_ID: ${{ needs.draft-release.outputs.release-id }}
+        with:
+          script: |
+            github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: process.env.RELEASE_ID,
+              draft: false
+            });


### PR DESCRIPTION
This PR changes the CI structure.

Pros:
- more structured and idiomatic according to Github Actions
- less code repetition, DRY
- better extensibility and flexibility

Cons:
- the bug with `/` in the action names at the UI (we have worked around it with `@` symbol and reverse order of the mode / platform)
- work duplication between potentially reused runs (i.e. release and build `docker` jobs) - yes, but really we'd want them to be retriggered either way because we want them to run with separate refs - and then it's all about the caches to eliminate extra work